### PR TITLE
CI checks out the repo using a GH app token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+---
 name: ci
 
 on:
@@ -41,14 +42,21 @@ jobs:
             kv/data/MavenCentral  "PRIVATE_GPG_KEY" | MAVEN_GPG_PRIVATE_KEY;
             kv/data/MavenCentral  "TOKEN_USERNAME" | TOKEN_USERNAME;
             kv/data/MavenCentral  "TOKEN_PASSWORD" | TOKEN_PASSWORD;
-      - 
+      -
         name: Info
         run: echo "Using proto ${{ github.event.inputs.proto_ref }} with sha ${{ github.event.inputs.proto_sha }}"
-      - 
+      -
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_KEY }}
+      -
         name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       -
         name: Install deps
         run: make deps
@@ -61,7 +69,7 @@ jobs:
       -
         name: Build
         run: make build
-      - 
+      -
         name: Commit changes
         if: github.event_name == 'workflow_dispatch'
         uses: EndBug/add-and-commit@v9
@@ -69,7 +77,7 @@ jobs:
           default_author: github_actions
           add: 'pom.xml src'
           push: origin HEAD:main
-  
+
   test:
     runs-on: ubuntu-latest
     needs: build
@@ -92,12 +100,12 @@ jobs:
             kv/data/MavenCentral  "PRIVATE_GPG_KEY" | MAVEN_GPG_PRIVATE_KEY;
             kv/data/MavenCentral  "TOKEN_USERNAME" | TOKEN_USERNAME;
             kv/data/MavenCentral  "TOKEN_PASSWORD" | TOKEN_PASSWORD;
-      - 
+      -
         name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - 
+      -
         name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
@@ -115,12 +123,13 @@ jobs:
       -
         name: Install package
         run: make install
-      - 
+      -
         name: Setup Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-      - 
+      -
         name: Install topaz
-        run: brew tap aserto-dev/tap && brew install aserto-dev/tap/topaz && topaz install && topaz templates install todo --no-console --force
+        run: |
+          brew tap aserto-dev/tap && brew install aserto-dev/tap/topaz && topaz install && topaz templates install todo --no-console --force
       -
         name: Build examples
         working-directory: examples
@@ -131,14 +140,14 @@ jobs:
         run: |
           cp assets/.env.topaz-directory.example .env
           java -jar target/examples-1.0.0-SNAPSHOT-shaded.jar
-        
+
   release:
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     name: Release to maven central
     steps:
-      - 
+      -
         name: Read configuration
         uses: hashicorp/vault-action@v3
         id: vault
@@ -156,12 +165,19 @@ jobs:
             kv/data/MavenCentral  "PRIVATE_GPG_KEY" | MAVEN_GPG_PRIVATE_KEY;
             kv/data/MavenCentral  "TOKEN_USERNAME" | TOKEN_USERNAME;
             kv/data/MavenCentral  "TOKEN_PASSWORD" | TOKEN_PASSWORD;
-      - 
+      -
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_KEY }}
+      -
         name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - 
+          token: ${{ steps.app-token.outputs.token }}
+      -
         name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@v4
         with:
@@ -172,23 +188,23 @@ jobs:
           server-password: TOKEN_PASSWORD
           gpg-private-key: ${{ env.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-      - 
+      -
         name: Build
         run: make build
-      - 
+      -
         name: Create release
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           artifacts: "${{ github.workspace }}/target/*.jar"
           token: ${{ secrets.GITHUB_TOKEN }}
-      - 
+      -
         name: Publish to the Maven Central Repository
         run: make deploy
-      - 
+      -
         name: Bump to the next version
         run: make bump
-      - 
+      -
         name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
The app is allowed to bypass branch protection rules in the repo. This setup ensures that branch protection is enforced for human contributors, but the automated workflow can generate code and commit it to main.